### PR TITLE
refactor(editor): Add workspace ignore rules management

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "cSpell.words": ["loreignore"]
 }

--- a/TODO.md
+++ b/TODO.md
@@ -12,15 +12,26 @@
 - [Feature] Automatic image reference updates on file watcher events
 - [Feature] Smart image candidate search by hash for relocated images
 - [Feature] Bulk image path update system for moved/renamed images
+- [Feature] File Explorer enhancements (Sprint 4+)
+  - Drag & drop support for moving files
+  - Multi-selection (Ctrl+Click, Shift+Click)
+  - Context menu using Tauri built-in
+  - Real-time search/filter in explorer
+  - Keyboard navigation (arrows, Enter, etc.)
 
 ## To Do (Prioritized)
-- [Feature] Image Registry backend with SHA-256 hashing
-- [Feature] Image references index system (image_references.json)
-- [Feature] Missing image detection and validation on workspace open
-- [Feature] MissingImagePlaceholder component with relocate/remove actions
-- [Feature] Image reference tracking and sync on file save
-- [Feature] Project Health Panel for image issues (missing/orphaned)
-- [Feature] Manual image relocation workflow in character forms
+- [CRITICAL] Refactor File System Watcher 
+  - Fix cross-platform path filtering (Windows duplicates bug)
+- [HIGH] Redesign File Explorer UI 
+  - Custom hierarchical tree component (FileTreeNode.vue)
+  - Optimize index updates (incremental instead of full refresh)
+  - Dual representation: tree + flat list for search
+  - Client-side filtering as safety net
+- [MEDIUM] .loreignore system 
+  - Create .loreignore with sensible defaults
+  - Tauri commands for reading/updating ignore rules
+  - Hot reload of ignore matcher on .loreignore changes
+  - Optional: UI editor for ignore rules in Settings
 - [Feature] Orphaned images cleanup with user confirmation
 - [Feature] Implement markdown image drag-and-drop support
 - [Enhancement] Visual feedback improvements for long operations
@@ -38,6 +49,10 @@
 - [Feature] Dynamic character forms configuration (includes custom fields in `.lore/character_form_config.toml`)
 
 ## Done
+- [CRITICAL] Refactor File System Watcher  - 2025-11-17
+  - Integrate `ignore` crate with .loreignore support
+  - Implement granular file system events (created/modified/deleted/renamed)
+  - Improve debouncing (500ms + event coalescence)
 - [Bug] Cannot scroll in the log console - 2025-11-16
 - [Feature] Add vue-virtual-scroller to the log console - 2025-11-16
 - [Feature] Upload Character Image in form view - 2025-11-16

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -74,7 +74,6 @@ pub fn run() {
             lore_editor::open_file_in_editor,
             lore_editor::create_new_file,
             lore_editor::get_welcome_text,
-            lore_editor::stop_watching_workspace,
             lore_editor::refresh_file_tree,
             lore_editor::create_file_from_template,
             lore_workspaces::open_existing_workspace,
@@ -86,7 +85,16 @@ pub fn run() {
             lore_workspaces::validate_image_index,
             lore_workspaces::find_image_candidates,
             lore_workspaces::bulk_update_image_path,
+            lore_editor::get_ignore_rules,
+            lore_editor::update_ignore_rules,
+            lore_editor::close_workspace,
         ])
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::Destroyed = event {
+                // Cleanup when window is destroyed
+                let _ = lore_editor::FileSystemWatcher::stop_all();
+            }
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/apps/desktop/src/components/ui/sidebar/Sidebar.vue
+++ b/apps/desktop/src/components/ui/sidebar/Sidebar.vue
@@ -74,7 +74,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
     <div
       :class="cn(
       'fixed bottom-0 z-10 hidden w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
-        'inset-y-0 h-svh',
+        'top-0 bottom-6',
         side === 'left'
           ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
           : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',

--- a/apps/desktop/src/modules/editor/layouts/EditorLayout.vue
+++ b/apps/desktop/src/modules/editor/layouts/EditorLayout.vue
@@ -1,37 +1,37 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
-import { useEditorStore } from '@editor/stores/editor.store'
-import EditorMenubar from '@editor/components/EditorMenubar.vue'
-import FilesystemSidebar from '@editor/components/FilesystemSidebar.vue'
-import EditorTabs from '@editor/components/EditorTabs.vue'
-import EditorContent from '@editor/components/EditorContent.vue'
-import ConsolePanel from '@editor/components/ConsolePanel.vue'
-import InspectorPanel from '@editor/components/InspectorPanel.vue'
-import StatusFooter from '@editor/components/StatusFooter.vue'
+import { computed } from "vue";
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { useEditorStore } from "@editor/stores/editor.store";
+import EditorMenubar from "@editor/components/EditorMenubar.vue";
+import FilesystemSidebar from "@editor/components/FilesystemSidebar.vue";
+import EditorTabs from "@editor/components/EditorTabs.vue";
+import EditorContent from "@editor/components/EditorContent.vue";
+import ConsolePanel from "@editor/components/ConsolePanel.vue";
+import InspectorPanel from "@editor/components/InspectorPanel.vue";
+import StatusFooter from "@editor/components/StatusFooter.vue";
 
-const editorStore = useEditorStore()
+const editorStore = useEditorStore();
 
 const isCharacterFile = computed(() => {
-  return editorStore.activeTab?.path?.endsWith('.character.md') || false
-})
+  return editorStore.activeTab?.path?.endsWith(".character.md") || false;
+});
 
 const toggleConsole = () => {
-  editorStore.toggleConsole()
-}
+  editorStore.toggleConsole();
+};
 
 const isIndexing = computed(() => {
-  return editorStore.indexingProgress && !editorStore.indexingProgress.completed
-})
+  return editorStore.indexingProgress && !editorStore.indexingProgress.completed;
+});
 
 const indexingProgress = computed(() => {
-  if (!editorStore.indexingProgress) return 0
+  if (!editorStore.indexingProgress) return 0;
 
-  const { processed, total } = editorStore.indexingProgress
-  if (total === 0) return 0
+  const { processed, total } = editorStore.indexingProgress;
+  if (total === 0) return 0;
 
-  return Math.floor((processed / total) * 100)
-})
+  return Math.floor((processed / total) * 100);
+});
 </script>
 
 <template>
@@ -42,14 +42,14 @@ const indexingProgress = computed(() => {
           <SidebarTrigger />
         </div>
 
-        <FilesystemSidebar class="flex-shrink-0 h-full z-10" />
+        <FilesystemSidebar class="shrink-0 h-full z-10" />
 
         <div class="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden relative">
           <EditorTabs
             :files="editorStore.openTabs"
             :active-tab="editorStore.activeTabId"
             @close-tab="editorStore.closeTab"
-            class="flex-shrink-0"
+            class="shrink-0"
           />
 
           <div class="flex-1 min-h-0 overflow-hidden bg-background">
@@ -59,32 +59,25 @@ const indexingProgress = computed(() => {
               :file="editorStore.activeTab"
               class="h-full"
             />
-            <div
-              v-else
-              class="flex items-center justify-center h-full text-muted-foreground"
-            >
+            <div v-else class="flex items-center justify-center h-full text-muted-foreground">
               Select a file to view its content or create a new one.
             </div>
           </div>
 
-          <ConsolePanel
-            v-if="editorStore.showConsole"
-            @close="toggleConsole"
-            class="flex-shrink-0"
-          />
+          <ConsolePanel v-if="editorStore.showConsole" @close="toggleConsole" class="shrink-0" />
         </div>
 
         <InspectorPanel
           v-if="editorStore.showInspector && !isCharacterFile"
           :file="editorStore.activeTab"
-          class="flex-shrink-0 h-full"
+          class="shrink-0 h-full"
         />
       </div>
 
       <StatusFooter
         :is-indexing="!!isIndexing"
         :progress="indexingProgress"
-        class="flex-shrink-0 z-20"
+        class="shrink-0 relative z-50"
       />
     </SidebarProvider>
   </div>

--- a/crates/lore-editor/src/ignore.rs
+++ b/crates/lore-editor/src/ignore.rs
@@ -1,0 +1,104 @@
+use anyhow::{Context, Result};
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use std::path::Path;
+use std::sync::Arc;
+
+const DEFAULT_LOREIGNORE: &str = r#"# Lore Designer - File Explorer Ignore Rules
+# Syntax: same as .gitignore
+
+# Internal directories
+.lore/
+.git/
+
+# Build artifacts
+node_modules/
+dist/
+build/
+target/
+
+# System files
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Temporary files
+*.tmp
+*.bak
+~*
+*.swp
+*.swo
+
+# User can add custom patterns below:
+"#;
+
+pub struct IgnoreMatcher {
+    gitignore: Gitignore,
+    workspace_path: Arc<Path>,
+}
+
+impl IgnoreMatcher {
+    pub fn new(workspace_path: impl AsRef<Path>) -> Result<Self> {
+        let workspace = workspace_path.as_ref();
+        let ignore_path = workspace.join(".loreignore");
+
+        if !ignore_path.exists() {
+            Self::create_default_loreignore(&ignore_path)?;
+        }
+
+        let mut builder = GitignoreBuilder::new(workspace);
+        builder.add(&ignore_path);
+
+        let gitignore = builder.build()?;
+
+        Ok(Self {
+            gitignore,
+            workspace_path: Arc::from(workspace),
+        })
+    }
+
+pub fn should_ignore(&self, path: &Path) -> bool {
+    let relative_path = match path.strip_prefix(&*self.workspace_path) {
+        Ok(rel) => rel,
+        Err(_) => return false, // If we can't get relative path, don't ignore
+    };
+
+    // Always ignore anything in .lore directory
+    if let Some(first_component) = relative_path.components().next()
+        && first_component.as_os_str() == ".lore" {
+            return true;
+        }
+
+    // Check against gitignore rules
+    self.gitignore
+        .matched(relative_path, path.is_dir())
+        .is_ignore()
+}
+
+    pub fn reload(&mut self) -> Result<()> {
+        let ignore_path = self.workspace_path.join(".loreignore");
+        let mut builder = GitignoreBuilder::new(&*self.workspace_path);
+        builder.add(&ignore_path);
+        self.gitignore = builder.build()?;
+        Ok(())
+    }
+
+    fn create_default_loreignore(path: &Path) -> Result<()> {
+        std::fs::write(path, DEFAULT_LOREIGNORE)
+            .context("Failed to create default .loreignore file")
+    }
+}
+
+pub fn get_loreignore_content(workspace_path: impl AsRef<Path>) -> Result<String> {
+    let ignore_path = workspace_path.as_ref().join(".loreignore");
+
+    if !ignore_path.exists() {
+        return Ok(DEFAULT_LOREIGNORE.to_string());
+    }
+
+    std::fs::read_to_string(&ignore_path).context("Failed to read .loreignore file")
+}
+
+pub fn update_loreignore_content(workspace_path: impl AsRef<Path>, content: String) -> Result<()> {
+    let ignore_path = workspace_path.as_ref().join(".loreignore");
+    std::fs::write(&ignore_path, content).context("Failed to update .loreignore file")
+}

--- a/crates/lore-editor/src/lib.rs
+++ b/crates/lore-editor/src/lib.rs
@@ -6,6 +6,7 @@ mod model;
 mod state;
 mod templates;
 mod watcher;
+mod ignore;
 
 pub use commands::*;
 pub use editor::*;
@@ -13,6 +14,7 @@ pub use index::*;
 pub use model::*;
 pub use state::*;
 pub use watcher::*;
+pub use ignore::*;
 
 use crate::frontmatter::combine_frontmatter_and_content;
 use anyhow::Context;


### PR DESCRIPTION
Implement new commands for managing workspace ignore rules
and closing workspaces. Remove deprecated stop_watching_workspace
function. Improve error handling and provide more robust
workspace management capabilities.